### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is the Routine [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server.
 
+<a href="https://glama.ai/mcp/servers/@routineco/mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@routineco/mcp-server/badge" alt="Routine MCP server" />
+</a>
+
 ## Usage
 
 1. Run the [Routine](https://routine.co/download) application for the MCP server to work.


### PR DESCRIPTION
This PR adds a badge for the [Routine](https://glama.ai/mcp/servers/@routineco/mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@routineco/mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@routineco/mcp-server/badge" alt="Routine MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.